### PR TITLE
Do not show hidden sub-commands as valid command options

### DIFF
--- a/sphinx_click/ext.py
+++ b/sphinx_click/ext.py
@@ -271,6 +271,11 @@ def _format_command(ctx, show_nested, commands=None):
         yield ''
 
     for command in commands:
+        # Don't show hidden subcommands
+        if CLICK_VERSION >= (7, 0):
+            if command.hidden:
+                continue
+
         for line in _format_subcommand(command):
             yield line
         yield ''


### PR DESCRIPTION
This PR ensures that sub-commands which have been marked as 'hidden' (requires Click >= 7.0), are not shown as valid command options in the documentation generated for the higher level command.

Closes #33 