### PR TITLE
Add click.Choice options to help text

### DIFF
--- a/sphinx_click/ext.py
+++ b/sphinx_click/ext.py
@@ -60,6 +60,11 @@ def _get_help_record(opt):
         extra.append('required')
     if extra:
         help = '%s[%s]' % (help and help + '  ' or '', '; '.join(extra))
+    if isinstance(opt.type, click.Choice):
+        help = "%s  Options: <%s>" % (
+            help and help + "  " or "",
+            ", ".join(opt.type.choices),
+        )
 
     return ', '.join(rv), help
 

--- a/sphinx_click/ext.py
+++ b/sphinx_click/ext.py
@@ -61,9 +61,9 @@ def _get_help_record(opt):
     if extra:
         help = '%s[%s]' % (help and help + '  ' or '', '; '.join(extra))
     if isinstance(opt.type, click.Choice):
-        help = "%s  Options: <%s>" % (
+        help = "%s\n\n:options: %s" % (
             help and help + "  " or "",
-            ", ".join(opt.type.choices),
+            "|".join(opt.type.choices),
         )
 
     return ', '.join(rv), help

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -66,7 +66,9 @@ class CommandTestCase(unittest.TestCase):
 
         .. option:: --choice <choice>
 
-            A sample option with choices    Options: <Option1, Option2>
+            A sample option with choices
+
+            :options: Option1|Option2
 
         .. rubric:: Arguments
 

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -40,6 +40,7 @@ class CommandTestCase(unittest.TestCase):
 
         @click.command()
         @click.option('--param', envvar='PARAM', help='A sample option')
+        @click.option('--choice', help='A sample option with choices', type=click.Choice(['Option1', 'Option2']))
         @click.argument('ARG', envvar='ARG')
         def foobar(bar):
             """A sample command."""
@@ -62,6 +63,10 @@ class CommandTestCase(unittest.TestCase):
         .. option:: --param <param>
 
             A sample option
+
+        .. option:: --choice <choice>
+
+            A sample option with choices    Options: <Option1, Option2>
 
         .. rubric:: Arguments
 


### PR DESCRIPTION
If an option has `type=click.Choice`, this will extract the options
and place it at the end of the help text.

It will look like this:

![image](https://user-images.githubusercontent.com/6462439/59369598-611b2580-8d06-11e9-9fee-505b14f0f7a1.png)

Also adds a test case for this.

This should resolve #35 and #41