### PR TITLE
Don't show hidden commands in toctree

### DIFF
--- a/sphinx_click/ext.py
+++ b/sphinx_click/ext.py
@@ -354,6 +354,9 @@ class ClickDirective(rst.Directive):
         :returns: A list of nested docutil nodes
         """
         ctx = click.Context(command, info_name=name, parent=parent)
+        
+        if CLICK_VERSION >= (7, 0) and command.hidden:
+            return []
 
         # Title
 


### PR DESCRIPTION
Hidden commands still appear in the table of contents. This PR is intended to remove them from the toctree.