### PR TITLE
fix: when `show_default` is a string use it as the default description

### DIFF
--- a/sphinx_click/ext.py
+++ b/sphinx_click/ext.py
@@ -55,7 +55,7 @@ def _get_help_record(opt):
             # Starting from Click 7.0 this can be a string as well. This is
             # mostly useful when the default is not a constant and
             # documentation thus needs a manually written string.
-            extra.append('default: %s' % opt.show_default,)
+            extra.append('default: %s' % opt.show_default)
         else:
             extra.append('default: %s' %
                          (', '.join('%s' % d for d in opt.default) if isinstance(

--- a/sphinx_click/ext.py
+++ b/sphinx_click/ext.py
@@ -51,8 +51,11 @@ def _get_help_record(opt):
     help = opt.help or ''
     extra = []
     if opt.default is not None and opt.show_default:
-        extra.append('default: %s' %
-                     (', '.join('%s' % d for d in opt.default) if isinstance(
+        if isinstance(opt.show_default, str):
+            extra.append('default: %s' % opt.show_default,)
+        else:
+            extra.append('default: %s' %
+                         (', '.join('%s' % d for d in opt.default) if isinstance(
                          opt.default, (list, tuple)) else opt.default, ))
     if opt.required:
         extra.append('required')

--- a/sphinx_click/ext.py
+++ b/sphinx_click/ext.py
@@ -52,6 +52,9 @@ def _get_help_record(opt):
     extra = []
     if opt.default is not None and opt.show_default:
         if isinstance(opt.show_default, str):
+            # Starting from Click 7.0 this can be a string as well. This is
+            # mostly useful when the default is not a constant and
+            # documentation thus needs a manually written string.
             extra.append('default: %s' % opt.show_default,)
         else:
             extra.append('default: %s' %

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -95,6 +95,42 @@ class CommandTestCase(unittest.TestCase):
         """).lstrip(), '\n'.join(output))
 
     @unittest.skipIf(ext.CLICK_VERSION < (7, 0),
+                     'Allowing show_default to be a string was added in Click 7.0')
+    def test_defaults(self):
+        """Validate formatting of user documented defaults.
+        """
+
+        @click.command()
+        @click.option('--num-param', type=int, default=42, show_default=True)
+        @click.option('--param', default=lambda: None, show_default='Something computed at runtime')
+        def foobar(bar):
+            """A sample command."""
+            pass
+
+        ctx = click.Context(foobar, info_name='foobar')
+        output = list(ext._format_command(ctx, show_nested=False))
+
+        self.assertEqual(
+            textwrap.dedent("""
+        A sample command.
+
+        .. program:: foobar
+        .. code-block:: shell
+
+            foobar [OPTIONS]
+
+        .. rubric:: Options
+
+        .. option:: --num-param <num_param>
+
+            [default: 42]
+
+        .. option:: --param <param>
+
+            [default: Something computed at runtime]
+        """).lstrip(), '\n'.join(output))
+
+    @unittest.skipIf(ext.CLICK_VERSION < (7, 0),
                      'The hidden flag was added in Click 7.0')
     def test_hidden(self):
         """Validate a `click.Command` with the `hidden` flag."""


### PR DESCRIPTION
Because this value doesn't just function as a boolean. When it's a
string it's intended to allow the user to override the documentation of
the default.

This parameter's alternative value is documented in https://click.palletsprojects.com/en/7.x/api/?highlight=show_default#click.Option