### PR TITLE
Possibility to generate a flat toctree with subcommands

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -38,6 +38,9 @@ Once enabled, *sphinx-click* enables automatic documentation for
    ``:show-nested:``
      Enable full documentation for sub-commands.
 
+   ``:flat-toctree:``
+     Generate a flat toctree for nested commands (by a hierarchical one is generated)
+
    ``:commands:``
      Document only listed commands.
 


### PR DESCRIPTION
Hello @stephenfin, while building the documentation of a pipeline CLI tool (subcommands = stage in the pipeline), I found I'd rather have a flat toctree with all subcommands, instead of them being subsection of the main command. In this patch, I've added a `:flat-toctree:` flag for that purpose. Let me know if this makes sense.