### PR TITLE
Make show-nested more granualar

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -36,7 +36,9 @@ Once enabled, *sphinx-click* enables automatic documentation for
    The following options are optional:
 
    ``:show-nested:``
-     Enable full documentation for sub-commands.
+     Set to "full" to enable full documentation for sub-commands. Set to "no"
+     to entirely omit sub-commands. Set to short to only list sub-commands.
+     Defaults to "short".
 
    ``:commands:``
      Document only listed commands.

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -36,9 +36,12 @@ Once enabled, *sphinx-click* enables automatic documentation for
    The following options are optional:
 
    ``:show-nested:``
+     This option is deprecated, please use ``nested`` instead.
+
+   ``:nested:``
      Set to "full" to enable full documentation for sub-commands. Set to "no"
-     to entirely omit sub-commands. Set to short to only list sub-commands.
-     Defaults to "short".
+     to entirely omit sub-commands. Set to "short" to only list sub-commands.
+     Defaults to "short", unless ``show-nested`` is set.
 
    ``:commands:``
      Document only listed commands.

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -308,14 +308,14 @@ class NestedCommandsTestCase(unittest.TestCase):
             A sample command.
         """).lstrip(), '\n'.join(output))
 
-    def test_show_nested(self):
+    def test_nested_full(self):
         """Validate a nested command with show_nested.
 
         If we're not showing sub-commands separately, we should not list them.
         """
 
         ctx = self._get_ctx()
-        output = list(ext._format_command(ctx, show_nested=True))
+        output = list(ext._format_command(ctx, show_nested="full"))
 
         self.assertEqual(
             textwrap.dedent("""
@@ -325,6 +325,31 @@ class NestedCommandsTestCase(unittest.TestCase):
         .. code-block:: shell
 
             cli [OPTIONS] COMMAND [ARGS]...
+        """).lstrip(), '\n'.join(output))
+
+    def test_nested_short(self):
+        """Validate a nested command with show_nested.
+
+        If we're not showing sub-commands separately, we should not list them.
+        """
+
+        ctx = self._get_ctx()
+        output = list(ext._format_command(ctx, show_nested="short"))
+
+        self.assertEqual(
+            textwrap.dedent("""
+        A sample command group.
+
+        .. program:: cli
+        .. code-block:: shell
+
+            cli [OPTIONS] COMMAND [ARGS]...
+
+        .. rubric:: Commands
+
+        .. object:: hello
+
+            A sample command.
         """).lstrip(), '\n'.join(output))
 
 


### PR DESCRIPTION
I want to entirely hide commands (and render them elsewhere) because of how my documentation is structured.

This change allows a more flexible show-nested, but retains backwards-compatibility to avoid breaking any existing integrations.

I'm happy to iterate on this if you feel there are improvements to be made to my approach.