### PR TITLE
Add whitespace to option choice separator to allow wrapping

### DIFF
--- a/sphinx_click/ext.py
+++ b/sphinx_click/ext.py
@@ -88,7 +88,7 @@ def _get_help_record(opt):
             )
 
     if isinstance(opt.type, click.Choice):
-        extras.append(':options: %s' % '|'.join(opt.type.choices))
+        extras.append(':options: %s' % ' | '.join(opt.type.choices))
 
     if extras:
         if out:

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -84,7 +84,7 @@ class CommandTestCase(unittest.TestCase):
 
             A sample option with choices
 
-            :options: Option1|Option2
+            :options: Option1 | Option2
 
         .. rubric:: Arguments
 


### PR DESCRIPTION
For choice lists that end up being long (due to many available choices or the length of choice names), having the separator be just a `|` with no whitespace forces the choices to always be on a single line, which can force it outside the border of the doc. 

This change turns this:
![no_whitespace_example](https://user-images.githubusercontent.com/12001407/88332758-ade87280-ccf4-11ea-80ea-2637b41d0669.png)
Into this:
![whitespace_example](https://user-images.githubusercontent.com/12001407/88332767-b3de5380-ccf4-11ea-85f3-f766eaac8821.png)
