### PR TITLE
Add support to ppc64le

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: python
 cache: pip
+arch: 
+- amd64
+- ppc64le
 python:
 - 2.7
 - 3.5


### PR DESCRIPTION
Add support to linux on power little endian architecture. sphinx-click is part of ubuntu distribution on this platform also. Continuously building/testing it on ppc64le along with amd64 will ensure that we detect/fix failures if any in the early stage.