### PR TITLE
ENH allow for grouped documentation with CommandCollection

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -15,7 +15,7 @@ needs_sphinx = '1.5'
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = []
+extensions = ["sphinx_click"]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = []

--- a/docs/examples/commandcollections.rst
+++ b/docs/examples/commandcollections.rst
@@ -1,0 +1,27 @@
+.. _example_commandcollections:
+
+Documentating |CommandCollection|
+=================================
+
+The client in the file ``examples/commandcollections/cli.py`` using a
+|CommandCollection| such as
+
+.. literalinclude:: ../../examples/commandcollections/cli.py
+
+The automatic documentation using *sphinx-click* gives for the following directive:
+
+.. code-block:: rst
+
+   .. click:: commandcollections.cli:cli
+     :prog: cli
+     :nested: full
+
+----
+
+.. click:: commandcollections.cli:cli
+  :prog: cli
+  :nested: full
+
+
+.. |CommandCollection| replace:: ``CommandCollection``
+.. _CommandCollection: https://click.palletsprojects.com/en/7.x/api/#click.CommandCollection

--- a/docs/examples/commandcollections.rst
+++ b/docs/examples/commandcollections.rst
@@ -1,14 +1,11 @@
-.. _example_commandcollections:
-
-Documentating |CommandCollection|
+Documenting |CommandCollection|
 =================================
 
-The client in the file ``examples/commandcollections/cli.py`` using a
-|CommandCollection| such as
+Consider the following sample application, using |CommandCollection|_:
 
 .. literalinclude:: ../../examples/commandcollections/cli.py
 
-The automatic documentation using *sphinx-click* gives for the following directive:
+This can be documented using *sphinx-click* like so:
 
 .. code-block:: rst
 

--- a/docs/examples/index.rst
+++ b/docs/examples/index.rst
@@ -1,0 +1,8 @@
+Examples
+========
+
+.. toctree::
+   :maxdepth: 1
+   :glob:
+
+   *

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -15,6 +15,7 @@ __ http://click.pocoo.org/
    usage
    contributing
    changelog
+   examples/index
 
 .. seealso::
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -147,6 +147,27 @@ the roles provided by the `Sphinx standard domain`_.
 
     __ https://github.com/sphinx-doc/sphinx/issues/880
 
+Documenting |CommandCollection|_
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When building more complex CLI, one might need to bring together multiple groups
+of commands and make them accessible using a single client with |CommandCollection|_.
+*sphinx-click* renders collection of commands with multiple sections, one for each
+group listed in the command ``sources``. The group names are used as section titles
+and the help string from the description are used as section description.
+Thus, a client defined using a |CommandCollection| as ``cli`` will be rendered
+using *sphinx-click* and the following directive
+
+.. code-block:: rst
+
+   .. click:: cli:cli
+      :prog: cli
+      :nested: full
+
+with the subcommands of each group in different sections, one for each group in
+``sources``. An example is provided in :ref:`example_commandcollections`.
+
+
 Modifying ``sys.path``
 ----------------------
 
@@ -184,3 +205,6 @@ assuming the group or command in ``git.git`` is named ``cli``.
 
 Refer to `issue #2 <https://github.com/click-contrib/sphinx-click/issues/2>`__
 for more information.
+
+.. |CommandCollection| replace:: :code:`CommandCollection`
+.. _CommandCollection: https://click.palletsprojects.com/en/7.x/api/#click.CommandCollection

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -155,8 +155,8 @@ of commands and make them accessible using a single client with |CommandCollecti
 *sphinx-click* renders collection of commands with multiple sections, one for each
 group listed in the command ``sources``. The group names are used as section titles
 and the help string from the description are used as section description.
-Thus, a client defined using a |CommandCollection| as ``cli`` will be rendered
-using *sphinx-click* and the following directive
+Thus, a client defined using a |CommandCollection| as ``cli`` can be rendered
+using *sphinx-click* and the following directive:
 
 .. code-block:: rst
 
@@ -164,8 +164,8 @@ using *sphinx-click* and the following directive
       :prog: cli
       :nested: full
 
-with the subcommands of each group in different sections, one for each group in
-``sources``. An example is provided in :ref:`example_commandcollections`.
+This will render the subcommands of each group in different sections, one for each
+group in ``sources``. An example is provided in :doc:`examples/commandcollections`.
 
 
 Modifying ``sys.path``

--- a/examples/commandcollections/cli.py
+++ b/examples/commandcollections/cli.py
@@ -1,0 +1,40 @@
+# file: cli.py
+import click
+
+
+main = click.Group(
+    name='Principal Commands',
+    help="Principal commands that are used in ``cli``.\n\n"
+    "The section name and description are obtained using the name and "
+    "description of the group passed as sources for |CommandCollection|_."
+)
+
+
+@main.command(help='CMD 1')
+def cmd1():
+    print('call cmd 1')
+
+
+helpers = click.Group(
+    name='Helper Commands',
+    help="Helper commands for ``cli``."
+)
+
+
+@helpers.command()
+def cmd2():
+    "Helper command that has no option."
+    pass
+
+
+@helpers.command()
+@click.option('--user', type=str)
+def cmd3(user):
+    "Helper command with an option."
+    pass
+
+
+cli = click.CommandCollection(
+    name='cli', sources=[main, helpers],
+    help='Some general info on ``cli``.'
+)

--- a/examples/setup.py
+++ b/examples/setup.py
@@ -1,0 +1,7 @@
+from setuptools import find_packages, setup
+
+setup(
+    name='sphinx_click_examples',
+    packages=find_packages('.'),
+    install_requires=['click']
+)

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -670,3 +670,75 @@ class CustomMultiCommandTestCase(unittest.TestCase):
             ).lstrip(),
             '\n'.join(output),
         )
+
+
+class CommandCollectionTestCase(unittest.TestCase):
+    """Validate ``click.CommandCollection`` instances."""
+
+    def test_basics(self):
+        "Validate a ``click.CommandCollection`` with grouped outputs."
+
+        @click.group()
+        def grp1():
+            """A first group."""
+            pass
+
+        @grp1.command()
+        def hello():
+            """A hello command."""
+
+        @click.group()
+        def grp2():
+            """A second group."""
+            pass
+
+        @grp2.command()
+        def world():
+            """A world command."""
+
+        cli = click.CommandCollection(
+            name='cli', sources=[grp1, grp2],
+            help='A simple CommandCollection.'
+        )
+        ctx = click.Context(cli, info_name='cli')
+        output = list(ext._format_command(ctx, nested='full'))
+
+        self.assertEqual(
+            textwrap.dedent(
+                """
+        A simple CommandCollection.
+
+        .. program:: cli
+        .. code-block:: shell
+
+            cli [OPTIONS] COMMAND [ARGS]...
+        """
+            ).lstrip(),
+            '\n'.join(output),
+        )
+
+        output = list(ext._format_command(ctx, nested='short'))
+
+        self.assertEqual(
+            textwrap.dedent(
+                """
+        A simple CommandCollection.
+
+        .. program:: cli
+        .. code-block:: shell
+
+            cli [OPTIONS] COMMAND [ARGS]...
+
+        .. rubric:: Commands
+
+        .. object:: hello
+
+            A hello command.
+
+        .. object:: world
+
+            A world command.
+        """
+            ).lstrip(),
+            '\n'.join(output),
+        )

--- a/tox.ini
+++ b/tox.ini
@@ -29,6 +29,7 @@ branch = True
 
 [testenv:docs]
 commands =
+    pip install -e {toxinidir}/examples/
     sphinx-build -W -b html -d docs/_build/doctrees docs docs/_build/html
 
 [travis]


### PR DESCRIPTION
While building a CLI with many different subcommands, I splitted them in groups and merged together using a `CommandCollections`.
When documenting this CLI, I wanted to preserve this group structure. I ended up tweaking a bit the `sphinx-click` extension to show the groups in `sources` as sections, without breaking the API. See here for an example of the results obtained: https://517-227720375-gh.circle-artifacts.com/0/dev/cli.html#benchopt

I ported the code for this in this PR. Let me know if you think it might interest others, I can try to document this change and make a few examples if you think it is worth it :) Else, feel free to close this PR. It might be too specific to my use case.