### PR TITLE
Explicitly add used requires, don't require pbr on runtime

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-pbr>=2.0
 sphinx>=1.5,<4.0
 click>=6.0,<8.0
 docutils

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 pbr>=2.0
 sphinx>=1.5,<4.0
+click>=6.0,<8.0
+docutils


### PR DESCRIPTION

- This does not make much sense without click,
  the version range comes from tox.ini.
- Docutils is a transitive dependency from sphinx,
  but this extension currently imports from it directly.
- Pbr is only used to build this package.