### PR TITLE
Remove any ANSI escape sequences from cli documentation: epilog and options

### DIFF
--- a/sphinx_click/ext.py
+++ b/sphinx_click/ext.py
@@ -145,7 +145,7 @@ def _format_option(opt):
     if opt[1]:
         yield ''
         for line in statemachine.string2lines(
-            opt[1], tab_width=4, convert_whitespace=True
+            ANSI_ESC_SEQ_RE.sub('', opt[1]), tab_width=4, convert_whitespace=True
         ):
             yield _indent(line)
 
@@ -241,12 +241,13 @@ def _format_epilog(ctx):
     We parse this as reStructuredText, allowing users to embed rich
     information in their help messages if they so choose.
     """
-    epilog_string = ctx.command.epilog
-    if not epilog_string:
+    if not ctx.command.epilog:
         return
 
     for line in statemachine.string2lines(
-        epilog_string, tab_width=4, convert_whitespace=True
+        ANSI_ESC_SEQ_RE.sub('', ctx.command.epilog),
+        tab_width=4,
+        convert_whitespace=True,
     ):
         yield line
     yield ''

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -269,7 +269,23 @@ class CommandTestCase(unittest.TestCase):
     def test_ansi_escape_sequences(self):
         """Validate that ANSI escape sequences are stripped."""
 
-        @click.command()
+        @click.command(epilog='\033[31mA sample epilog.\033[0m')
+        @click.option(
+            '--name',
+            help='Name to say \033[94mhello\033[0m to.',
+            required=True,
+            type=str,
+        )
+        @click.option(
+            '--choice',
+            help='A sample option with choices',
+            type=click.Choice(['\033[94mOption1\033[0m', '\033[94mOption2\033[0m']),
+        )
+        @click.option(
+            '--param',
+            default=lambda: None,
+            show_default='Something computed at \033[94mruntime\033[0m',
+        )
         def foobar():
             """A sample command with **sparkles**.
 
@@ -293,6 +309,24 @@ class CommandTestCase(unittest.TestCase):
         .. code-block:: shell
 
             foobar [OPTIONS]
+
+        .. rubric:: Options
+
+        .. option:: --name <name>
+
+            **Required** Name to say hello to.
+
+        .. option:: --choice <choice>
+
+            A sample option with choices
+
+            :options: Option1 | Option2
+
+        .. option:: --param <param>
+
+            :default: Something computed at runtime
+
+        A sample epilog.
         """
             ).lstrip(),
             '\n'.join(output),


### PR DESCRIPTION
Following the commit of de245b51ffd40c75c50bb86a3e761c1edb0947b1 that attempted to strip the ANSI escape codes (the problem described in the https://github.com/click-contrib/sphinx-click/issues/77), this PR 
* strips the ANSI escape codes from the command's epilog
* strips the ANSI escape codes from the command's options