### PR TITLE
Remove "sphinx_click" from extensions in conf.py

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -15,7 +15,7 @@ needs_sphinx = '1.5'
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = ["sphinx_click"]
+extensions = []
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = []


### PR DESCRIPTION
Hey,
I want to update sphinx-click to v. 2.7.1 in Fedora and encountered an error while building the project docs. 
It seems the change introduced in #73 is responsible. I guess it's a leftover from the dev environment? If not, feel free to correct me.
Thanks!