### PR TITLE
Add typing hints

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -26,3 +26,14 @@ packages =
 [flake8]
 max-line-length = 88
 ignore = E203,E501,E741,W503
+
+[mypy]
+python_version = 3.6
+# disallow_incomplete_defs = True
+show_column_numbers = True
+show_error_context = True
+ignore_missing_imports = True
+follow_imports = skip
+check_untyped_defs = True
+warn_unused_ignores = True
+strict_optional = False

--- a/sphinx_click/ext.py
+++ b/sphinx_click/ext.py
@@ -213,7 +213,9 @@ def _format_envvar(param: Union[Option, Argument]) -> str:
 
 def _format_envvars(ctx: Context) -> str:
     """Format all envvars for a `click.Command`."""
-    params = [x for x in ctx.command.params if getattr(x, 'envvar')]
+    params = [
+        x for x in ctx.command.params if isinstance(x, (Option, Argument)) and x.envvar
+    ]
 
     for param in params:
         yield '.. _{command_name}-{param_name}-{envvar}:'.format(

--- a/sphinx_click/ext.py
+++ b/sphinx_click/ext.py
@@ -31,7 +31,7 @@ NESTED_NONE = 'none'
 ANSI_ESC_SEQ_RE = re.compile(r'\x1B\[\d+(;\d+){0,2}m', flags=re.MULTILINE)
 
 
-def _indent(text: str, level=1) -> str:
+def _indent(text: str, level: int = 1) -> str:
     prefix = ' ' * (4 * level)
 
     def prefixed_lines() -> Generator[str]:

--- a/sphinx_click/ext.py
+++ b/sphinx_click/ext.py
@@ -1,6 +1,7 @@
 import re
 import traceback
 import warnings
+from typing import Generator
 from typing import Iterable
 from typing import List
 from typing import Optional
@@ -33,7 +34,7 @@ ANSI_ESC_SEQ_RE = re.compile(r'\x1B\[\d+(;\d+){0,2}m', flags=re.MULTILINE)
 def _indent(text: str, level=1) -> str:
     prefix = ' ' * (4 * level)
 
-    def prefixed_lines() -> str:
+    def prefixed_lines() -> Generator[str]:
         for line in text.splitlines(True):
             yield (prefix + line if line.strip() else line)
 
@@ -112,7 +113,7 @@ def _get_help_record(opt: Option) -> Tuple[str, str]:
     return ', '.join(rv), '\n'.join(out)
 
 
-def _format_description(ctx: Context) -> str:
+def _format_description(ctx: Context) -> Generator[str]:
     """Format the description for a given `click.Command`.
 
     We parse this as reStructuredText, allowing users to embed rich
@@ -138,7 +139,7 @@ def _format_description(ctx: Context) -> str:
     yield ''
 
 
-def _format_usage(ctx: Context) -> str:
+def _format_usage(ctx: Context) -> Generator[str]:
     """Format the usage for a `click.Command`."""
     yield '.. code-block:: shell'
     yield ''
@@ -147,7 +148,7 @@ def _format_usage(ctx: Context) -> str:
     yield ''
 
 
-def _format_option(opt: Option) -> str:
+def _format_option(opt: Option) -> Generator[str]:
     """Format the output for a `click.Option`."""
     opt_help = _get_help_record(opt)
 
@@ -160,7 +161,7 @@ def _format_option(opt: Option) -> str:
             yield _indent(line)
 
 
-def _format_options(ctx: Context) -> str:
+def _format_options(ctx: Context) -> Generator[str]:
     """Format all `click.Option` for a `click.Command`."""
     # the hidden attribute is part of click 7.x only hence use of getattr
     params = [
@@ -175,7 +176,7 @@ def _format_options(ctx: Context) -> str:
         yield ''
 
 
-def _format_argument(arg: Argument) -> str:
+def _format_argument(arg: Argument) -> Generator[str]:
     """Format the output of a `click.Argument`."""
     yield '.. option:: {}'.format(arg.human_readable_name)
     yield ''
@@ -186,7 +187,7 @@ def _format_argument(arg: Argument) -> str:
     )
 
 
-def _format_arguments(ctx: Context) -> str:
+def _format_arguments(ctx: Context) -> Generator[str]:
     """Format all `click.Argument` for a `click.Command`."""
     params = [x for x in ctx.command.params if isinstance(x, click.Argument)]
 
@@ -196,7 +197,7 @@ def _format_arguments(ctx: Context) -> str:
         yield ''
 
 
-def _format_envvar(param: Union[Option, Argument]) -> str:
+def _format_envvar(param: Union[Option, Argument]) -> Generator[str]:
     """Format the envvars of a `click.Option` or `click.Argument`."""
     yield '.. envvar:: {}'.format(param.envvar)
     yield '   :noindex:'
@@ -211,7 +212,7 @@ def _format_envvar(param: Union[Option, Argument]) -> str:
     yield _indent('Provide a default for :option:`{}`'.format(param_ref))
 
 
-def _format_envvars(ctx: Context) -> str:
+def _format_envvars(ctx: Context) -> Generator[str]:
     """Format all envvars for a `click.Command`."""
     params = [
         x for x in ctx.command.params if isinstance(x, (Option, Argument)) and x.envvar
@@ -229,7 +230,7 @@ def _format_envvars(ctx: Context) -> str:
         yield ''
 
 
-def _format_subcommand(command: Command) -> str:
+def _format_subcommand(command: Command) -> Generator[str]:
     """Format a sub-command of a `click.Command` or `click.Group`."""
     yield '.. object:: {}'.format(command.name)
 
@@ -243,7 +244,7 @@ def _format_subcommand(command: Command) -> str:
             yield _indent(line)
 
 
-def _format_epilog(ctx: Context) -> str:
+def _format_epilog(ctx: Context) -> Generator[str]:
     """Format the epilog for a given `click.Command`.
 
     We parse this as reStructuredText, allowing users to embed rich

--- a/tox.ini
+++ b/tox.ini
@@ -35,4 +35,10 @@ commands =
 [travis]
 python =
   3.6: py36, docs
-  3.7: py37, style
+  3.7: py37, style, mypy
+
+[testenv:mypy]
+deps =
+    mypy
+commands =
+    mypy sphinx_click


### PR DESCRIPTION
This is an attempt at add type hints to the codebase.

I'm mostly doing this since I want to better understand some of the
helper functions so as to expose a few and make them reusable.

There's still a issues in `_format_envvars` and `_generate_nodes`. Both
of them take an argument and pass it to a conflicting function.

There's a second commit to this PR which has a change of which I'm not fully sure. That's not a typing change, but an actual logic change. It does work for me, however, I can't really say it's correct. It does remove one typing error.