### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 sphinx>=2.0
-click>=6.0
+click>=7.0
 docutils


### PR DESCRIPTION
Support for Click 6.0 was dropped on this commit: https://github.com/click-contrib/sphinx-click/commit/7fef5bc0d94ffba62abc7f1445795429ed2b3172