### PR TITLE
Return Sphinx extension metadata

### DIFF
--- a/sphinx_click/ext.py
+++ b/sphinx_click/ext.py
@@ -511,3 +511,8 @@ class ClickDirective(rst.Directive):
 
 def setup(app):
     app.add_directive('click', ClickDirective)
+
+    return {
+        'parallel_read_safe': False,
+        'parallel_write_safe': False,
+    }

--- a/sphinx_click/ext.py
+++ b/sphinx_click/ext.py
@@ -513,6 +513,6 @@ def setup(app):
     app.add_directive('click', ClickDirective)
 
     return {
-        'parallel_read_safe': False,
-        'parallel_write_safe': False,
+        'parallel_read_safe': True,
+        'parallel_write_safe': True,
     }


### PR DESCRIPTION
Presently, when using with Sphinx I get the following warning:

```
WARNING: the sphinx_click extension does not declare if it is safe for parallel reading, assuming it isn't - please ask the extension author to check and make it explicit
WARNING: doing serial read
```

This PR returns the metadata declarations as per [their docs](https://www.sphinx-doc.org/en/master/extdev/index.html#ext-metadata). I have set the parallel safe to True, as it appears you have no global state that would prevent this use.

