### PR TITLE
Add support for pre-wrapped epilogs

### DIFF
--- a/sphinx_click/ext.py
+++ b/sphinx_click/ext.py
@@ -101,16 +101,7 @@ def _get_help_record(opt):
     return ', '.join(rv), '\n'.join(out)
 
 
-def _format_description(ctx):
-    """Format the description for a given `click.Command`.
-
-    We parse this as reStructuredText, allowing users to embed rich
-    information in their help messages if they so choose.
-    """
-    help_string = ctx.command.help or ctx.command.short_help
-    if not help_string:
-        return
-
+def _format_help(help_string):
     help_string = ANSI_ESC_SEQ_RE.sub('', help_string)
 
     bar_enabled = False
@@ -125,6 +116,17 @@ def _format_description(ctx):
         line = '| ' + line if bar_enabled else line
         yield line
     yield ''
+
+
+def _format_description(ctx):
+    """Format the description for a given `click.Command`.
+
+    We parse this as reStructuredText, allowing users to embed rich
+    information in their help messages if they so choose.
+    """
+    help_string = ctx.command.help or ctx.command.short_help
+    if help_string:
+        yield from _format_help(help_string)
 
 
 def _format_usage(ctx):
@@ -236,23 +238,8 @@ def _format_epilog(ctx):
     We parse this as reStructuredText, allowing users to embed rich
     information in their help messages if they so choose.
     """
-    if not ctx.command.epilog:
-        return
-
-    bar_enabled = False
-    for line in statemachine.string2lines(
-        ANSI_ESC_SEQ_RE.sub('', ctx.command.epilog),
-        tab_width=4,
-        convert_whitespace=True,
-    ):
-        if line == '\b':
-            bar_enabled = True
-            continue
-        if line == '':
-            bar_enabled = False
-        line = '| ' + line if bar_enabled else line
-        yield line
-    yield ''
+    if ctx.command.epilog:
+        yield from _format_help(ctx.command.epilog)
 
 
 def _get_lazyload_commands(multicommand):

--- a/sphinx_click/ext.py
+++ b/sphinx_click/ext.py
@@ -239,11 +239,18 @@ def _format_epilog(ctx):
     if not ctx.command.epilog:
         return
 
+    bar_enabled = False
     for line in statemachine.string2lines(
         ANSI_ESC_SEQ_RE.sub('', ctx.command.epilog),
         tab_width=4,
         convert_whitespace=True,
     ):
+        if line == '\b':
+            bar_enabled = True
+            continue
+        if line == '':
+            bar_enabled = False
+        line = '| ' + line if bar_enabled else line
         yield line
     yield ''
 

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -461,6 +461,52 @@ class GroupTestCase(unittest.TestCase):
             '\n'.join(output),
         )
 
+    def test_no_line_wrapping_epilog(self):
+        r"""Validate behavior of the \b character in an epilog."""
+
+        @click.command(
+            epilog="""
+An epilog containing pre-wrapped text.
+
+\b
+This is
+a paragraph
+without rewrapping.
+
+And this is a paragraph
+that will be rewrapped again.
+"""
+        )
+        def foobar():
+            """A sample command."""
+
+        ctx = click.Context(foobar, info_name='foobar')
+        output = list(ext._format_command(ctx, nested='short'))
+
+        self.assertEqual(
+            textwrap.dedent(
+                """
+        A sample command.
+
+        .. program:: foobar
+        .. code-block:: shell
+
+            foobar [OPTIONS]
+
+
+        An epilog containing pre-wrapped text.
+
+        | This is
+        | a paragraph
+        | without rewrapping.
+
+        And this is a paragraph
+        that will be rewrapped again.
+        """
+            ).lstrip(),
+            '\n'.join(output),
+        )
+
 
 class NestedCommandsTestCase(unittest.TestCase):
     """Validate ``click.Command`` instances inside ``click.Group`` instances."""


### PR DESCRIPTION
Putting `\b` on a line by itself suppresses Click's rewrapping for the following paragraph. In `sphinx-click` this was already supported for main help texts, but not yet in epilogs, while Click supports it in epilogs as well.
