### PR TITLE
display `show_default` string even when `default=None`

### DIFF
--- a/sphinx_click/ext.py
+++ b/sphinx_click/ext.py
@@ -73,21 +73,21 @@ def _get_help_record(opt):
 
     extras = []
 
-    if opt.default is not None and opt.show_default:
-        if isinstance(opt.show_default, str):
-            # Starting from Click 7.0 this can be a string as well. This is
-            # mostly useful when the default is not a constant and
-            # documentation thus needs a manually written string.
-            extras.append(':default: %s' % opt.show_default)
-        else:
-            extras.append(
-                ':default: %s'
-                % (
-                    ', '.join(str(d) for d in opt.default)
-                    if isinstance(opt.default, (list, tuple))
-                    else opt.default,
-                )
+
+    if isinstance(opt.show_default, str):
+        # Starting from Click 7.0 show_default can be a string. This is
+        # mostly useful when the default is not a constant and
+        # documentation thus needs a manually written string.
+        extras.append(':default: %s' % opt.show_default)
+    elif opt.default is not None and opt.show_default:
+        extras.append(
+            ':default: %s'
+            % (
+                ', '.join(str(d) for d in opt.default)
+                if isinstance(opt.default, (list, tuple))
+                else opt.default,
             )
+        )
 
     if isinstance(opt.type, click.Choice):
         extras.append(':options: %s' % ' | '.join(str(x) for x in opt.type.choices))

--- a/sphinx_click/ext.py
+++ b/sphinx_click/ext.py
@@ -73,7 +73,6 @@ def _get_help_record(opt):
 
     extras = []
 
-
     if isinstance(opt.show_default, str):
         # Starting from Click 7.0 show_default can be a string. This is
         # mostly useful when the default is not a constant and

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -177,6 +177,10 @@ class CommandTestCase(unittest.TestCase):
             multiple=True,
             show_default=True,
         )
+        @click.option(
+            '--only-show-default',
+            show_default="Some default computed at runtime!",
+        )
         def foobar(bar):
             """A sample command."""
             pass
@@ -207,6 +211,10 @@ class CommandTestCase(unittest.TestCase):
         .. option:: --group <group>
 
             :default: ('foo', 'bar')
+
+        .. option:: --only-show-default <only_show_default>
+
+            :default: Some default computed at runtime!
         """
             ).lstrip(),
             '\n'.join(output),


### PR DESCRIPTION
fixes #93 