### PR TITLE
Correct 'get_command' argument type error

### DIFF
--- a/sphinx_click/ext.py
+++ b/sphinx_click/ext.py
@@ -249,7 +249,7 @@ def _format_epilog(ctx: click.Context) -> ty.Generator[str, None, None]:
 def _get_lazyload_commands(ctx: click.Context) -> ty.Dict[str, click.Command]:
     commands = {}
     for command in ctx.command.list_commands(ctx):
-        commands[command] = ctx.command.get_command(ctx.command, command)
+        commands[command] = ctx.command.get_command(ctx, command)
 
     return commands
 


### PR DESCRIPTION
A previous fix partially resolve an issue with incorrect command type passed to
list_commands, but the same fix should have been applied to get_command as
well.

Close #70 (again).