### PR TITLE
Use `asyncclick` when available

### DIFF
--- a/sphinx_click/ext.py
+++ b/sphinx_click/ext.py
@@ -4,7 +4,10 @@ import traceback
 import typing as ty
 import warnings
 
-import click
+try:
+    import asyncclick as click
+except ImportError:
+    import click
 from docutils import nodes
 from docutils.parsers import rst
 from docutils.parsers.rst import directives

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,13 @@
 [tox]
 minversion = 2.0
-envlist = py{37,38,39}-click{7,8},py{310}-click8,style,docs
+envlist = py{37,38,39}-click{7,8,8-async},py{310}-click{8,8-async},style,docs
 
 [testenv]
 deps =
     coverage
     click7: click>=7.0,<8.0
     click8: click>=8.0,<9.0
+    click8-async: asyncclick>=8.0,<9.0
 commands =
     coverage run --source={toxinidir}/sphinx_click -m unittest {posargs}
     coverage report


### PR DESCRIPTION
Currently build fails with:

`cli-reference.rst:1: ERROR: "<class 'asyncclick.core.Group'>" of type "dipdup.cli:cli" is not click.Command or click.Group."click.BaseCommand"`

`asyncclick` is a drop-in replacement for `click`, [as shown](https://github.com/python-trio/asyncclick#a-simple-example) in official docs, so it should be perfectly safe to use it without any further modifications.

Related: #95 