### PR TITLE
add functionality to also render env-variables that are created via the 'auto_envvar_prefix' option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,6 @@ ChangeLog
 
 # vim
 *.swp
+
+# Intellij
+.idea

--- a/sphinx_click/ext.py
+++ b/sphinx_click/ext.py
@@ -218,7 +218,16 @@ def _format_envvar(
 
 def _format_envvars(ctx: click.Context) -> ty.Generator[str, None, None]:
     """Format all envvars for a `click.Command`."""
-    params = [x for x in ctx.command.params if x.envvar]
+
+    auto_envvar_prefix = ctx.auto_envvar_prefix
+    if auto_envvar_prefix is not None:
+        params = []
+        for param in ctx.command.params:
+            if not param.envvar:
+                param.envvar = f"{auto_envvar_prefix}_{param.name.upper()}"
+            params.append(param)
+    else:
+        params = [x for x in ctx.command.params if x.envvar]
 
     for param in params:
         yield '.. _{command_name}-{param_name}-{envvar}:'.format(

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -940,3 +940,78 @@ class CommandCollectionTestCase(unittest.TestCase):
             ).lstrip(),
             '\n'.join(output),
         )
+
+
+class AutoEnvvarPrefixTestCase(unittest.TestCase):
+    """Validate ``click auto_envvar_prefix``-setup instances."""
+
+    def test_basics(self):
+        """Validate a click application with ``auto_envvar_prefix`` option enabled."""
+
+        @click.command(
+            context_settings={"auto_envvar_prefix": "PREFIX"},
+        )
+        @click.option('--param', help='Help for param')
+        @click.option('--other-param', help='Help for other-param')
+        @click.option(
+            '--param-with-explicit-envvar',
+            help='Help for param-with-explicit-envvar',
+            envvar="EXPLICIT_ENVVAR",
+        )
+        def cli_with_auto_envvars():
+            """A simple CLI with auto-env vars ."""
+
+        cli = cli_with_auto_envvars
+        ctx = click.Context(cli, info_name='cli', auto_envvar_prefix="PREFIX")
+        output = list(ext._format_command(ctx, nested='full'))
+
+        self.assertEqual(
+            textwrap.dedent(
+                """
+        A simple CLI with auto-env vars .
+
+        .. program:: cli
+        .. code-block:: shell
+
+            cli [OPTIONS]
+
+        .. rubric:: Options
+
+        .. option:: --param <param>
+
+            Help for param
+
+        .. option:: --other-param <other_param>
+
+            Help for other-param
+
+        .. option:: --param-with-explicit-envvar <param_with_explicit_envvar>
+
+            Help for param-with-explicit-envvar
+
+        .. rubric:: Environment variables
+
+        .. _cli-param-PREFIX_PARAM:
+
+        .. envvar:: PREFIX_PARAM
+           :noindex:
+
+            Provide a default for :option:`--param`
+
+        .. _cli-other_param-PREFIX_OTHER_PARAM:
+
+        .. envvar:: PREFIX_OTHER_PARAM
+           :noindex:
+
+            Provide a default for :option:`--other-param`
+
+        .. _cli-param_with_explicit_envvar-EXPLICIT_ENVVAR:
+
+        .. envvar:: EXPLICIT_ENVVAR
+           :noindex:
+
+            Provide a default for :option:`--param-with-explicit-envvar`
+        """
+            ).lstrip(),
+            '\n'.join(output),
+        )


### PR DESCRIPTION
As described in https://github.com/click-contrib/sphinx-click/issues/105, there is currently no support in `sphinx-click` for the detection of Environment Variables Options that are automatically created via the [**auto_envvar_prefix** functionality](https://click.palletsprojects.com/en/7.x/options/#values-from-environment-variables).

In this Merge Request, this will be enabled.

Best Patrik