### PR TITLE
fix behavior of show_default with context_settings

### DIFF
--- a/sphinx_click/ext.py
+++ b/sphinx_click/ext.py
@@ -43,7 +43,7 @@ def _get_usage(ctx: click.Context) -> str:
     return formatter.getvalue().rstrip('\n')  # type: ignore
 
 
-def _get_help_record(opt: click.Option) -> ty.Tuple[str, str]:
+def _get_help_record(opt: click.Option, ctx: click.Context) -> ty.Tuple[str, str]:
     """Re-implementation of click.Opt.get_help_record.
 
     The variant of 'get_help_record' found in Click makes uses of slashes to
@@ -79,12 +79,17 @@ def _get_help_record(opt: click.Option) -> ty.Tuple[str, str]:
 
     extras = []
 
-    if isinstance(opt.show_default, str):
+    if opt.show_default is not None:
+        show_default = opt.show_default
+    else:
+        show_default =  ctx.show_default
+
+    if isinstance(show_default, str):
         # Starting from Click 7.0 show_default can be a string. This is
         # mostly useful when the default is not a constant and
         # documentation thus needs a manually written string.
-        extras.append(':default: ``%s``' % opt.show_default)
-    elif opt.default is not None and opt.show_default:
+        extras.append(':default: ``%s``' % show_default)
+    elif opt.default is not None and show_default:
         extras.append(
             ':default: ``%s``'
             % (
@@ -143,9 +148,9 @@ def _format_usage(ctx: click.Context) -> ty.Generator[str, None, None]:
     yield ''
 
 
-def _format_option(opt: click.Option) -> ty.Generator[str, None, None]:
+def _format_option(opt: click.Option, ctx: click.Context) -> ty.Generator[str, None, None]:
     """Format the output for a `click.Option`."""
-    opt_help = _get_help_record(opt)
+    opt_help = _get_help_record(opt, ctx)
 
     yield '.. option:: {}'.format(opt_help[0])
     if opt_help[1]:
@@ -173,7 +178,7 @@ def _format_options(ctx: click.Context) -> ty.Generator[str, None, None]:
     ]
 
     for param in params:
-        for line in _format_option(param):
+        for line in _format_option(param, ctx):
             yield line
         yield ''
 

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -231,6 +231,40 @@ class CommandTestCase(unittest.TestCase):
             '\n'.join(output),
         )
 
+    def test_show_default(self):
+        """Validate formatting of show_default via context_settings."""
+
+        @click.command(context_settings={"show_default": True})
+        @click.option('--no-set', default=0)
+        @click.option('--set-false', default=0, show_default=False)
+        def foobar():
+            """A sample command."""
+            pass
+
+        ctx = click.Context(foobar, info_name='foobar', show_default=True)
+        output = list(ext._format_command(ctx, nested='short'))
+        self.assertEqual(
+            textwrap.dedent(
+                """
+        A sample command.
+
+        .. program:: foobar
+        .. code-block:: shell
+
+            foobar [OPTIONS]
+
+        .. rubric:: Options
+
+        .. option:: --no-set <no_set>
+
+            :default: ``0``
+
+        .. option:: --set-false <set_false>
+        """
+            ).lstrip(),
+            '\n'.join(output),
+        )
+
     def test_hidden(self):
         """Validate a `click.Command` with the `hidden` flag."""
 


### PR DESCRIPTION
Closes #114 

## Core change

In `_get_help_record` function, added an argument `ctx` and added a variable `show_default`. 

This is almost the same implementation as [click's `_get_help_record` function](https://github.com/pallets/click/blob/main/src/click/core.py#L2750-L2756)
