### PR TITLE
Add Sphinx extension classifier

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -14,6 +14,7 @@ license = MIT License
 classifiers =
     Development Status :: 5 - Production/Stable
     Environment :: Console
+    Framework :: Sphinx :: Extension
     Intended Audience :: Developers
     Intended Audience :: Information Technology
     License :: OSI Approved :: MIT License


### PR DESCRIPTION
## Summary

Add the Sphinx Extension PyPi classifier so that the extension shows up in the correct [PyPi filters](https://pypi.org/search/?c=Framework+%3A%3A+Sphinx+%3A%3A+Extension).

## Tasks

<!-- Mark tasks as complete or not applicable using [x] -->

- [ ] Added unit tests (not applicable)
- [ ] Added documentation for new features (where applicable)
- [ ] Added release notes (using [`reno`](https://pypi.org/project/reno/))
- [ ] Ran test suite and style checks and built documentation (`tox`)

## Further details

<!-- Note any further details here, where applicable -->
