### PR TITLE
Add reference to complementary Click CLI documentation helpers

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -10,8 +10,8 @@ sphinx-click
     :target: https://sphinx-click.readthedocs.io/en/latest/?badge=latest
     :alt: Documentation Status
 
-`sphinx-click` is a `Sphinx`__ plugin that allows you to automatically extract
-documentation from a `click-based`__ application and include it in your docs.
+``sphinx-click`` is a `Sphinx`__ plugin that allows you to automatically extract
+documentation from a `Click-based`__ application and include it in your docs.
 
 __ http://www.sphinx-doc.org/
 __ http://click.pocoo.org/
@@ -19,13 +19,13 @@ __ http://click.pocoo.org/
 Installation
 ------------
 
-Install the plugin using `pip`:
+Install the plugin using ``pip``:
 
 .. code-block:: shell
 
    $ pip install sphinx-click
 
-Alternatively, install from source by cloning this repo then running `pip`
+Alternatively, install from source by cloning this repo then running ``pip``
 locally:
 
 .. code-block:: shell
@@ -37,10 +37,10 @@ Usage
 
 .. important::
 
-   To document a click-based application, both the application itself and any
+   To document a Click-based application, both the application itself and any
    additional dependencies required by that application **must be installed**.
 
-Enable the plugin in your Sphinx `conf.py` file:
+Enable the plugin in your Sphinx ``conf.py``` file:
 
 .. code-block:: python
 
@@ -57,3 +57,19 @@ documentation.
 
 Detailed information on the various options available is provided in the
 `documentation <https://sphinx-click.readthedocs.io>`_.
+
+Alternative
+-----------
+
+This plugin is perfect to document a Click-based CLI in Sphinx, as it properly
+renders the help screen and its options in nice HTML with deep links and
+styling.
+
+However, if you are looking to document the source code of a Click-based CLI,
+and the result of its execution, you might want to check out `click-extra`__.
+The latter provides the ``.. click:example::`` and ``.. click:run::`` Sphinx
+directives so you can `capture and render, with full colors, the result of your
+CLI in your documentation`__.
+
+__ https://github.com/kdeldycke/click-extra/
+__ https://kdeldycke.github.io/click-extra/sphinx.html


### PR DESCRIPTION
## Summary

As suggested by @stephenfin at https://github.com/click-contrib/sphinx-click/issues/110#issuecomment-1208039848, here is a little update to point users to complementary tools to help them document their Click-based CLI.

This PR also fixes some rST style rendering in the `README.rst`.

## Tasks

<!-- Mark tasks as complete or not applicable using [x] -->

- [x] Added unit tests
- [x] Added documentation for new features (where applicable)
- [x] Added release notes (using [`reno`](https://pypi.org/project/reno/))
- [x] Ran test suite and style checks and built documentation (`tox`)

## Further details

Here are some examples of real projects using `click-extra`'s `.. click:run::` to render the output of their `--help` option, followed by the rendering of `.. click::` directive from `sphinx-click` extension:
- [Meta Package Manager](https://kdeldycke.github.io/meta-package-manager/cli-parameters.html)
- [Mail Deduplicate](https://kdeldycke.github.io/mail-deduplicate/cli-parameters.html)
