### PR TITLE
Truncate help strings at "\f" characters, same as click

### DIFF
--- a/sphinx_click/ext.py
+++ b/sphinx_click/ext.py
@@ -108,6 +108,8 @@ def _get_help_record(opt: click.Option) -> ty.Tuple[str, str]:
 
 def _format_help(help_string: str) -> ty.Generator[str, None, None]:
     help_string = inspect.cleandoc(ANSI_ESC_SEQ_RE.sub('', help_string))
+    # Truncate at "\f" characters, same as click
+    help_string = help_string.partition("\f")[0]
 
     bar_enabled = False
     for line in statemachine.string2lines(
@@ -379,7 +381,6 @@ def nested(argument: ty.Optional[str]) -> ty.Optional[str]:
 
 
 class ClickDirective(rst.Directive):
-
     has_content = False
     required_arguments = 1
     option_spec = {


### PR DESCRIPTION
## Summary

Click truncates help strings at `\f` characters: https://click.palletsprojects.com/en/8.1.x/documentation/#truncating-help-texts

## Tasks

<!-- Mark tasks as complete or not applicable using [x] -->

- [ ] Added unit tests
- [ ] Added documentation for new features (where applicable)
- [ ] Added release notes (using [`reno`](https://pypi.org/project/reno/))
- [ ] Ran test suite and style checks and built documentation (`tox`)

## Further details

<!-- Note any further details here, where applicable -->
