### PR TITLE
Add support for mocking modules

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -59,6 +59,12 @@ Once enabled, *sphinx-click* enables automatic documentation for
    their options and their environment variables using the `Sphinx standard
    domain`_.
 
+*sphinx-click* allows for modules to be mocked out using the same method used by
+`sphinx.ext.autodoc`_. Modules to mock while the documentation is being built
+can be specified using the ``sphinx_click_mock_imports`` config value, if specified.
+Otherwise the value of ``autodoc_mock_imports`` is used, following the behavior
+of ``sphinx.ext.autosummary``. The value of this config option should be a list
+of module names; see `sphinx.ext.autodoc`_ for more information.
 
 .. _cross-referencing:
 
@@ -287,3 +293,4 @@ for more information.
 .. _ref role: https://www.sphinx-doc.org/en/master/usage/restructuredtext/roles.html#role-ref
 .. |envvar role| replace:: ``:envvar:``
 .. _envvar role: https://www.sphinx-doc.org/en/master/usage/restructuredtext/roles.html#role-envvar
+.. _sphinx.ext.autodoc: https://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html#confval-autodoc_mock_imports

--- a/releasenotes/notes/add-mock-modules-support-d4663c3265eeba5e.yaml
+++ b/releasenotes/notes/add-mock-modules-support-d4663c3265eeba5e.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    Added support for mocking imported modules during the build process. Mocked
+    modules can either be specified from a ``sphinx_click_mock_imports`` variable,
+    if specified, or by default using ``autodoc_mock_imports``.

--- a/tests/roots/basics/conf.py
+++ b/tests/roots/basics/conf.py
@@ -4,3 +4,5 @@ import sys
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
 extensions = ['sphinx_click']
+
+autodoc_mock_imports = ["fake_dependency"]

--- a/tests/roots/basics/greet.py
+++ b/tests/roots/basics/greet.py
@@ -1,12 +1,13 @@
 """The greet example taken from the README."""
 
 import click
+import fake_dependency  # Used to test that mocking works
 
 
 @click.group()
 def greet():
     """A sample command group."""
-    pass
+    fake_dependency.do_stuff("hello!")
 
 
 @greet.command()


### PR DESCRIPTION
## Summary

This PR adds support for mocking modules using the same machinery used by `autodoc` and `autosummary`.

See https://github.com/click-contrib/sphinx-click/pull/120 and https://github.com/click-contrib/sphinx-click/pull/88 for previous PRs related to this topic.

## Tasks

- [x] Added unit tests
- [x] Added documentation for new features (where applicable)
- [x] Added release notes (using [`reno`](https://pypi.org/project/reno/))
- [x] Ran test suite and style checks and built documentation (`tox`)

## Further details

Please let me know if anything else is required to merge this. I'd be happy to do whatever work is necessary to get this merged!