### PR TITLE
TST Add defusedxml to tox deps

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,7 @@ deps =
     pytest
     pytest-cov
     coverage
+    defusedxml
     click7: click>=7.0,<8.0
     click8: click>=8.0,<9.0
     click8-async: asyncclick>=8.0,<9.0

--- a/tox.ini
+++ b/tox.ini
@@ -15,6 +15,7 @@ deps =
     click7: click>=7.0,<8.0
     click8: click>=8.0,<9.0
     click8-async: asyncclick>=8.0,<9.0
+    defusedxml
 commands =
     python -m pytest --cov {toxinidir}/sphinx_click {posargs}
 pip_pre =


### PR DESCRIPTION
Otherwise tests fail with:
`ImportError: Error importing plugin "sphinx.testing.fixtures": No module named 'defusedxml'`.

See:
https://github.com/sphinx-doc/sphinx/issues/12339

## Tasks

<!-- Mark tasks as complete or not applicable using [x] -->

- [x] Added unit tests
- [x] Added documentation for new features (where applicable)
- [x] Added release notes (using [`reno`](https://pypi.org/project/reno/))
- [x] Ran test suite and style checks and built documentation (`tox`)

