### PR TITLE
FIX If the `help` of an argument is `None`, don't fail

### DIFF
--- a/sphinx_click/ext.py
+++ b/sphinx_click/ext.py
@@ -218,9 +218,10 @@ def _format_argument(arg: click.Argument) -> ty.Generator[str, None, None]:
         )
     )
     # Subclasses of click.Argument may add a `help` attribute (like typer.main.TyperArgument)
-    if hasattr(arg, 'help'):
+    help = getattr(arg, 'help', None)
+    if help:
         yield ''
-        help_string = ANSI_ESC_SEQ_RE.sub('', getattr(arg, 'help'))
+        help_string = ANSI_ESC_SEQ_RE.sub('', help)
         for line in _format_help(help_string):
             yield _indent(line)
 

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -185,6 +185,7 @@ class CommandTestCase(unittest.TestCase):
         @click.command()
         @click.option('--option', help='A sample option')
         @click.argument('ARG', help='A sample argument', cls=CustomArgument)
+        @click.argument('ARG_NO_HELP', cls=CustomArgument)
         def foobar(bar):
             """A sample command."""
             pass
@@ -200,7 +201,7 @@ class CommandTestCase(unittest.TestCase):
         .. program:: foobar
         .. code-block:: shell
 
-            foobar [OPTIONS] ARG
+            foobar [OPTIONS] ARG ARG_NO_HELP
 
         .. rubric:: Options
 
@@ -216,6 +217,10 @@ class CommandTestCase(unittest.TestCase):
 
             A sample argument
 
+
+        .. option:: ARG_NO_HELP
+
+            Required argument
         """
             ).lstrip(),
             '\n'.join(output),


### PR DESCRIPTION
## Summary

This is a fix for a regression introduced in #134. It's possible that the argument has a `help` attribute, but the value of it is `None`. We then hit a type error where we pass `None` to `re.sub`.

## Tasks

- [x] Added unit tests
- [x] Added documentation for new features (where applicable)
- [x] Added release notes (using [`reno`](https://pypi.org/project/reno/))
- [x] Ran test suite and style checks and built documentation (`tox`)

(no release note needed since it's a fix for an unreleased feature)