### PR TITLE
really drop python<=3.7 support

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # sphinx-click documentation build configuration file
 


### PR DESCRIPTION
## Summary
Filter all code over `pyupgrade --py38-plus`.

## Tasks
- [ ] Added unit tests
- [ ] Added documentation for new features (where applicable)
- [ ] Added release notes (using [`reno`](https://pypi.org/project/reno/))
- [ ] Ran test suite and style checks and built documentation (`tox`)

## Further details
N/A
