### PR TITLE
Print "Usage" w/ rubric before printing the command usage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,6 @@ ChangeLog
 
 # Intellij
 .idea
+
+# VSCode
+.vscode

--- a/releasenotes/notes/print-usage-c83518ec412eca7c.yaml
+++ b/releasenotes/notes/print-usage-c83518ec412eca7c.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    Add a "Usage" label (rubric) before printing the command's usage format.

--- a/sphinx_click/ext.py
+++ b/sphinx_click/ext.py
@@ -372,9 +372,7 @@ def _format_command(
 
     lines = list(_format_options(ctx))
     if lines:
-        # we use rubric to provide some separation without exploding the table
-        # of contents
-        yield '.. rubric:: Options'
+        yield '.. rubric:: Optionz'
         yield ''
 
     for line in lines:

--- a/sphinx_click/ext.py
+++ b/sphinx_click/ext.py
@@ -372,7 +372,7 @@ def _format_command(
 
     lines = list(_format_options(ctx))
     if lines:
-        yield '.. rubric:: Optionz'
+        yield '.. rubric:: Options'
         yield ''
 
     for line in lines:

--- a/sphinx_click/ext.py
+++ b/sphinx_click/ext.py
@@ -358,7 +358,14 @@ def _format_command(
 
     # usage
 
-    for line in _format_usage(ctx):
+    lines = list(_format_usage(ctx))
+    if lines:
+        # we use rubric to provide some separation without exploding the table
+        # of contents
+        yield '.. rubric:: Usage'
+        yield ''
+
+    for line in lines:
         yield line
 
     # options

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -20,8 +20,9 @@ def test_basics(make_app, rootdir):
     #     section:
     #       title:
     #       paragraph:
+    #       rubric:  (Usage)
     #       literal_block:
-    #       rubric:
+    #       rubric:  (Commands)
     #       index:
     #       desc:
     #         desc_signature:
@@ -38,16 +39,18 @@ def test_basics(make_app, rootdir):
     assert section[0].astext() == 'greet'
     assert isinstance(section[1], nodes.paragraph)
     assert section[1].astext() == 'A sample command group.'
-    assert isinstance(section[2], nodes.literal_block)
+    assert isinstance(section[2], nodes.rubric)
+    assert section[2].astext() == 'Usage'
+    assert isinstance(section[3], nodes.literal_block)
 
-    assert isinstance(section[3], nodes.rubric)
-    assert section[3].astext() == 'Commands'
-    assert isinstance(section[4], sphinx_nodes.index)
-    assert isinstance(section[5], sphinx_nodes.desc)
-    assert section[5].astext() == 'hello\n\nGreet a user.'
-    assert isinstance(section[6], sphinx_nodes.index)
-    assert isinstance(section[7], sphinx_nodes.desc)
-    assert section[7].astext() == 'world\n\nGreet the world.'
+    assert isinstance(section[4], nodes.rubric)
+    assert section[4].astext() == 'Commands'
+    assert isinstance(section[5], sphinx_nodes.index)
+    assert isinstance(section[6], sphinx_nodes.desc)
+    assert section[6].astext() == 'hello\n\nGreet a user.'
+    assert isinstance(section[7], sphinx_nodes.index)
+    assert isinstance(section[8], sphinx_nodes.desc)
+    assert section[8].astext() == 'world\n\nGreet the world.'
 
 
 def test_commands(make_app, rootdir):
@@ -66,8 +69,9 @@ def test_commands(make_app, rootdir):
     #     section:
     #       title:
     #       paragraph:
+    #       rubric:  (Usage)
     #       literal_block:
-    #       rubric:
+    #       rubric:  (Commands)
     #       index:
     #       desc:
     #         desc_signature:
@@ -80,14 +84,16 @@ def test_commands(make_app, rootdir):
     assert section[0].astext() == 'greet'
     assert isinstance(section[1], nodes.paragraph)
     assert section[1].astext() == 'A sample command group.'
-    assert isinstance(section[2], nodes.literal_block)
+    assert isinstance(section[2], nodes.rubric)
+    assert section[2].astext() == 'Usage'
+    assert isinstance(section[3], nodes.literal_block)
 
     # we should only show a single command, 'world'
-    assert isinstance(section[3], nodes.rubric)
-    assert section[3].astext() == 'Commands'
-    assert isinstance(section[4], sphinx_nodes.index)
-    assert isinstance(section[5], sphinx_nodes.desc)
-    assert section[5].astext() == 'world\n\nGreet the world.'
+    assert isinstance(section[4], nodes.rubric)
+    assert section[4].astext() == 'Commands'
+    assert isinstance(section[5], sphinx_nodes.index)
+    assert isinstance(section[6], sphinx_nodes.desc)
+    assert section[6].astext() == 'world\n\nGreet the world.'
 
 
 def test_nested_full(make_app, rootdir):
@@ -106,15 +112,18 @@ def test_nested_full(make_app, rootdir):
     #     section:
     #       title:
     #       paragraph:
+    #       rubric:  (Usage)
     #       literal_block:
     #       section:
     #         title
     #         paragraph
+    #         rubric:  (Usage)
     #         literal_block
     #         ...
     #       section:
     #         title
     #         paragraph
+    #         rubric:  (Usage)
     #         literal_block
 
     section = content[0][1]
@@ -124,23 +133,29 @@ def test_nested_full(make_app, rootdir):
     assert section[0].astext() == 'greet'
     assert isinstance(section[1], nodes.paragraph)
     assert section[1].astext() == 'A sample command group.'
-    assert isinstance(section[2], nodes.literal_block)
+    assert isinstance(section[2], nodes.rubric)
+    assert section[2].astext() == 'Usage'
+    assert isinstance(section[3], nodes.literal_block)
 
-    subsection_a = section[3]
+    subsection_a = section[4]
     assert isinstance(subsection_a, nodes.section)
 
     assert isinstance(subsection_a[0], nodes.title)
     assert subsection_a[0].astext() == 'hello'
     assert isinstance(subsection_a[1], nodes.paragraph)
     assert subsection_a[1].astext() == 'Greet a user.'
-    assert isinstance(subsection_a[2], nodes.literal_block)
+    assert isinstance(subsection_a[2], nodes.rubric)
+    assert subsection_a[2].astext() == 'Usage'
+    assert isinstance(subsection_a[3], nodes.literal_block)
     # we don't need to verify the rest of this: that's done elsewhere
 
-    subsection_b = section[4]
+    subsection_b = section[5]
     assert isinstance(subsection_b, nodes.section)
 
     assert isinstance(subsection_b[0], nodes.title)
     assert subsection_b[0].astext() == 'world'
     assert isinstance(subsection_b[1], nodes.paragraph)
     assert subsection_b[1].astext() == 'Greet the world.'
-    assert isinstance(subsection_b[2], nodes.literal_block)
+    assert isinstance(subsection_b[2], nodes.rubric)
+    assert subsection_b[2].astext() == 'Usage'
+    assert isinstance(subsection_b[3], nodes.literal_block)

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -31,6 +31,8 @@ class CommandTestCase(unittest.TestCase):
         A sample command.
 
         .. program:: foobar
+        .. rubric:: Usage
+
         .. code-block:: shell
 
             foobar [OPTIONS]
@@ -79,6 +81,8 @@ class CommandTestCase(unittest.TestCase):
         A sample command.
 
         .. program:: foobar
+        .. rubric:: Usage
+
         .. code-block:: shell
 
             foobar [OPTIONS] ARG
@@ -152,6 +156,8 @@ class CommandTestCase(unittest.TestCase):
         A sample command.
 
         .. program:: foobar
+        .. rubric:: Usage
+
         .. code-block:: shell
 
             foobar [OPTIONS]
@@ -197,6 +203,8 @@ class CommandTestCase(unittest.TestCase):
         A sample command.
 
         .. program:: foobar
+        .. rubric:: Usage
+
         .. code-block:: shell
 
             foobar [OPTIONS] ARG ARG_NO_HELP
@@ -261,6 +269,8 @@ class CommandTestCase(unittest.TestCase):
         A sample command.
 
         .. program:: foobar
+        .. rubric:: Usage
+
         .. code-block:: shell
 
             foobar [OPTIONS]
@@ -313,6 +323,8 @@ class CommandTestCase(unittest.TestCase):
         A sample command.
 
         .. program:: foobar
+        .. rubric:: Usage
+
         .. code-block:: shell
 
             foobar [OPTIONS]
@@ -374,6 +386,8 @@ class CommandTestCase(unittest.TestCase):
             my_cli hello --name "Jack"
 
         .. program:: hello
+        .. rubric:: Usage
+
         .. code-block:: shell
 
             hello [OPTIONS]
@@ -428,6 +442,8 @@ class CommandTestCase(unittest.TestCase):
         dash of bold and even some underlined words.
 
         .. program:: foobar
+        .. rubric:: Usage
+
         .. code-block:: shell
 
             foobar [OPTIONS]
@@ -495,6 +511,8 @@ class CommandTestCase(unittest.TestCase):
         :param click.core.Context ctx: Click context.
 
         .. program:: cli
+        .. rubric:: Usage
+
         .. code-block:: shell
 
             cli [OPTIONS]
@@ -564,6 +582,8 @@ that will be rewrapped again.
         that will be rewrapped again.
 
         .. program:: cli
+        .. rubric:: Usage
+
         .. code-block:: shell
 
             cli [OPTIONS]
@@ -621,6 +641,8 @@ class GroupTestCase(unittest.TestCase):
         A sample command group.
 
         .. program:: cli
+        .. rubric:: Usage
+
         .. code-block:: shell
 
             cli [OPTIONS] COMMAND [ARGS]...
@@ -652,6 +674,8 @@ class GroupTestCase(unittest.TestCase):
         A sample command group.
 
         .. program:: cli
+        .. rubric:: Usage
+
         .. code-block:: shell
 
             cli [OPTIONS] ARG COMMAND [ARGS]...
@@ -724,6 +748,8 @@ class NestedCommandsTestCase(unittest.TestCase):
         A sample command group.
 
         .. program:: cli
+        .. rubric:: Usage
+
         .. code-block:: shell
 
             cli [OPTIONS] COMMAND [ARGS]...
@@ -753,6 +779,8 @@ class NestedCommandsTestCase(unittest.TestCase):
         A sample command group.
 
         .. program:: cli
+        .. rubric:: Usage
+
         .. code-block:: shell
 
             cli [OPTIONS] COMMAND [ARGS]...
@@ -776,6 +804,8 @@ class NestedCommandsTestCase(unittest.TestCase):
         A sample command group.
 
         .. program:: cli
+        .. rubric:: Usage
+
         .. code-block:: shell
 
             cli [OPTIONS] COMMAND [ARGS]...
@@ -818,6 +848,8 @@ class CommandFilterTestCase(unittest.TestCase):
         A sample command group.
 
         .. program:: cli
+        .. rubric:: Usage
+
         .. code-block:: shell
 
             cli [OPTIONS] COMMAND [ARGS]...
@@ -840,6 +872,8 @@ class CommandFilterTestCase(unittest.TestCase):
         A sample command group.
 
         .. program:: cli
+        .. rubric:: Usage
+
         .. code-block:: shell
 
             cli [OPTIONS] COMMAND [ARGS]...
@@ -902,6 +936,8 @@ class CustomMultiCommandTestCase(unittest.TestCase):
         A sample custom multicommand.
 
         .. program:: cli
+        .. rubric:: Usage
+
         .. code-block:: shell
 
             cli [OPTIONS] COMMAND [ARGS]...
@@ -960,6 +996,8 @@ class CustomMultiCommandTestCase(unittest.TestCase):
         A sample custom multicommand.
 
         .. program:: cli
+        .. rubric:: Usage
+
         .. code-block:: shell
 
             cli [OPTIONS] COMMAND [ARGS]...
@@ -1017,6 +1055,8 @@ class CommandCollectionTestCase(unittest.TestCase):
         A simple CommandCollection.
 
         .. program:: cli
+        .. rubric:: Usage
+
         .. code-block:: shell
 
             cli [OPTIONS] COMMAND [ARGS]...
@@ -1033,6 +1073,8 @@ class CommandCollectionTestCase(unittest.TestCase):
         A simple CommandCollection.
 
         .. program:: cli
+        .. rubric:: Usage
+
         .. code-block:: shell
 
             cli [OPTIONS] COMMAND [ARGS]...
@@ -1083,6 +1125,8 @@ class AutoEnvvarPrefixTestCase(unittest.TestCase):
         A simple CLI with auto-env vars .
 
         .. program:: cli
+        .. rubric:: Usage
+
         .. code-block:: shell
 
             cli [OPTIONS]


### PR DESCRIPTION
## Summary

Add a "Usage" rubric before the printing the command usage, same as the "Options" rubric.

This provides a nice visual separation between the description text and the code showing the usage format, which is especially useful when the introduction is many paragraphs that includes other examples itself.

This is a pretty common format for CLI docs, although a lot of them say "Synopsis" instead, which I believe is a terrible word to use because it’s a very uncommon word.

## Tasks

<!-- Mark tasks as complete or not applicable using [x] -->

- [x] Added unit tests
- [x] Added documentation for new features (where applicable)
- [x] Added release notes (using [`reno`](https://pypi.org/project/reno/))
- [x] Ran test suite and style checks and built documentation (`tox`)

